### PR TITLE
fix:proxy of file

### DIFF
--- a/src/components/uploader.vue
+++ b/src/components/uploader.vue
@@ -65,8 +65,9 @@
         started.value = true
       }
       const fileAdded = (file) => {
-        emit(kebabCase(FILE_ADDED_EVENT), file)
-        if (file.ignored) {
+        const _file = reactive(file)
+        emit(kebabCase(FILE_ADDED_EVENT), _file)
+        if (_file.ignored) {
           // is ignored, filter it
           return false
         }


### PR DESCRIPTION
file应该是响应式的，否则file.cancel()调用后vue3无法响应修改fileList，导致取消上传后文件列表仍然显示，页面处在上传中的状态，这是vue2和vue3代理行为不一致导致的
#180 